### PR TITLE
Adopting the last bitflags version

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -56,43 +56,43 @@ pub enum ucl_emitter {
 
 bitflags! {
 #[repr(C)]
-    flags ucl_parser_flags_t: c_int {
-        const UCL_PARSER_DEFAULT = 0x0,
-        const UCL_PARSER_KEY_LOWERCASE = 0x1,
-        const UCL_PARSER_ZEROCOPY = 0x2,
-        const UCL_PARSER_NO_TIME = 0x4,
-        const UCL_PARSER_NO_IMPLICIT_ARRAYS = 0x8
+    pub struct ucl_parser_flags_t: c_int {
+        const UCL_PARSER_DEFAULT = 0x0;
+        const UCL_PARSER_KEY_LOWERCASE = 0x1;
+        const UCL_PARSER_ZEROCOPY = 0x2;
+        const UCL_PARSER_NO_TIME = 0x4;
+        const UCL_PARSER_NO_IMPLICIT_ARRAYS = 0x8;
     }
 }
 
 bitflags! {
 #[repr(C)]
-    flags ucl_string_flags_t : c_int {
-        const UCL_STRING_RAW = 0x0,
-        const UCL_STRING_ESCAPE = 0x1,
-        const UCL_STRING_TRIM = 0x2,
-        const UCL_STRING_PARSE_BOOLEAN = 0x4,
-        const UCL_STRING_PARSE_INT = 0x8,
-        const UCL_STRING_PARSE_DOUBLE = 0x10,
-        const UCL_STRING_PARSE_TIME = 0x20,
+    pub struct ucl_string_flags_t : c_int {
+        const UCL_STRING_RAW = 0x0;
+        const UCL_STRING_ESCAPE = 0x1;
+        const UCL_STRING_TRIM = 0x2;
+        const UCL_STRING_PARSE_BOOLEAN = 0x4;
+        const UCL_STRING_PARSE_INT = 0x8;
+        const UCL_STRING_PARSE_DOUBLE = 0x10;
+        const UCL_STRING_PARSE_TIME = 0x20;
         const UCL_STRING_PARSE_NUMBER = UCL_STRING_PARSE_INT.bits
             | UCL_STRING_PARSE_DOUBLE.bits
-            | UCL_STRING_PARSE_TIME.bits,
+            | UCL_STRING_PARSE_TIME.bits;
         const UCL_STRING_PARSE = UCL_STRING_PARSE_BOOLEAN.bits
-            | UCL_STRING_PARSE_NUMBER.bits,
-        const UCL_STRING_PARSE_BYTES = 0x40
+            | UCL_STRING_PARSE_NUMBER.bits;
+        const UCL_STRING_PARSE_BYTES = 0x40;
     }
 }
 
 bitflags! {
 #[repr(C)]
-    flags ucl_object_flags_t: c_int {
-        const UCL_OBJECT_ALLOCATED_KEY = 0x1,
-        const UCL_OBJECT_ALLOCATED_VALUE = 0x2,
-        const UCL_OBJECT_NEED_KEY_ESCAPE = 0x4,
-        const UCL_OBJECT_EPHEMERAL = 0x8,
-        const UCL_OBJECT_MULTILINE = 0x10,
-        const UCL_OBJECT_MULTIVALUE = 0x20
+    pub struct ucl_object_flags_t: c_int {
+        const UCL_OBJECT_ALLOCATED_KEY = 0x1;
+        const UCL_OBJECT_ALLOCATED_VALUE = 0x2;
+        const UCL_OBJECT_NEED_KEY_ESCAPE = 0x4;
+        const UCL_OBJECT_EPHEMERAL = 0x8;
+        const UCL_OBJECT_MULTILINE = 0x10;
+        const UCL_OBJECT_MULTIVALUE = 0x20;
     }
 }
 


### PR DESCRIPTION
The last versions of bitflags (>0.9) don't use `flags` anymore, but `struct`
